### PR TITLE
fix: disable iOS automatic number detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,13 +101,3 @@ php artisan config:clear
 php artisan route:clear
 php artisan view:clear
 ```
-
----
-
-Issue to solve: https://github.com/xierongchuan/VanillaCRM/issues/1
-Your prepared branch: issue-1-9c296167
-Your prepared working directory: /tmp/gh-issue-solver-1760133090452
-Your forked repository: konard/VanillaCRM
-Original repository (upstream): xierongchuan/VanillaCRM
-
-Proceed.


### PR DESCRIPTION
## Описание / Description

Добавлен мета-тег `<meta name="format-detection" content="telephone=no">` в главный шаблон `main.blade.php` для отключения автоматического преобразования больших чисел в кликабельные телефонные ссылки на iOS устройствах.

Added meta tag `<meta name="format-detection" content="telephone=no">` to the main template `main.blade.php` to disable automatic conversion of large numbers into clickable telephone links on iOS devices.

## Решение / Solution

- Добавлен мета-тег `format-detection` с параметром `telephone=no` в секцию `<head>` шаблона
- Мета-тег размещён после базовых мета-тегов viewport и CSRF token
- Теперь iOS Safari не будет автоматически определять и выделять числа как телефонные номера

## Изменённые файлы / Changed Files

- `resources/views/layouts/main.blade.php` - добавлен мета-тег на строке 9

## Тестирование / Testing

Решение основано на официальной документации Apple для iOS Safari и стандартных практиках веб-разработки. Мета-тег `format-detection` является стандартным решением для отключения автоматического определения телефонных номеров в iOS.

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)