### PR TITLE
Revert "fix: исправление тестов (CSRF защита и rate limiting)"

### DIFF
--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -88,8 +88,6 @@ class ApiTest extends TestCase
 
     public function test_api_login_validates_minimum_length(): void
     {
-        $this->withoutMiddleware(\Illuminate\Routing\Middleware\ThrottleRequests::class);
-
         $response = $this->postJson('/api/session', [
             'login' => 'abc',
             'password' => '12345',

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -29,11 +29,10 @@ class AuthenticationTest extends TestCase
             'role' => 'admin',
         ]);
 
-        $response = $this->from(route('auth.sign_in'))
-            ->post(route('auth.login'), [
-                'login' => 'testuser',
-                'password' => 'password123',
-            ]);
+        $response = $this->post(route('auth.login'), [
+            'login' => 'testuser',
+            'password' => 'password123',
+        ]);
 
         $response->assertRedirect(route('home.index'));
         $response->assertSessionHas('success', 'Вы успешно Аутентифицированы');
@@ -47,11 +46,10 @@ class AuthenticationTest extends TestCase
             'password' => Hash::make('password123'),
         ]);
 
-        $response = $this->from(route('auth.sign_in'))
-            ->post(route('auth.login'), [
-                'login' => 'testuser',
-                'password' => 'wrongpassword',
-            ]);
+        $response = $this->post(route('auth.login'), [
+            'login' => 'testuser',
+            'password' => 'wrongpassword',
+        ]);
 
         $response->assertRedirect();
         $response->assertSessionHasErrors('login');
@@ -60,10 +58,9 @@ class AuthenticationTest extends TestCase
 
     public function test_login_requires_login_field(): void
     {
-        $response = $this->from(route('auth.sign_in'))
-            ->post(route('auth.login'), [
-                'password' => 'password123',
-            ]);
+        $response = $this->post(route('auth.login'), [
+            'password' => 'password123',
+        ]);
 
         $response->assertSessionHasErrors('login');
         $this->assertGuest();
@@ -71,10 +68,9 @@ class AuthenticationTest extends TestCase
 
     public function test_login_requires_password_field(): void
     {
-        $response = $this->from(route('auth.sign_in'))
-            ->post(route('auth.login'), [
-                'login' => 'testuser',
-            ]);
+        $response = $this->post(route('auth.login'), [
+            'login' => 'testuser',
+        ]);
 
         $response->assertSessionHasErrors('password');
         $this->assertGuest();

--- a/tests/Feature/CompanyManagementTest.php
+++ b/tests/Feature/CompanyManagementTest.php
@@ -58,8 +58,7 @@ class CompanyManagementTest extends TestCase
             'data' => 'Some additional data',
         ];
 
-        $response = $this->from(route('company.create'))
-            ->post(route('company.store'), $companyData);
+        $response = $this->post(route('company.store'), $companyData);
 
         $response->assertRedirect(route('company.list'));
 
@@ -74,10 +73,9 @@ class CompanyManagementTest extends TestCase
 
         Company::factory()->create(['name' => 'Existing Company']);
 
-        $response = $this->from(route('company.create'))
-            ->post(route('company.store'), [
-                'name' => 'Existing Company',
-            ]);
+        $response = $this->post(route('company.store'), [
+            'name' => 'Existing Company',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -86,10 +84,9 @@ class CompanyManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.create'))
-            ->post(route('company.store'), [
-                'name' => 'AB',
-            ]);
+        $response = $this->post(route('company.store'), [
+            'name' => 'AB',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -98,10 +95,9 @@ class CompanyManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.create'))
-            ->post(route('company.store'), [
-                'name' => str_repeat('A', 21),
-            ]);
+        $response = $this->post(route('company.store'), [
+            'name' => str_repeat('A', 21),
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -125,10 +121,9 @@ class CompanyManagementTest extends TestCase
 
         $company = Company::factory()->create(['name' => 'Old Name']);
 
-        $response = $this->from(route('company.update', $company))
-            ->post(route('company.modify', $company), [
-                'name' => 'New Company Name',
-            ]);
+        $response = $this->post(route('company.modify', $company), [
+            'name' => 'New Company Name',
+        ]);
 
         $response->assertRedirect(route('company.list'));
         $response->assertSessionHas('success', 'Successfully updated');

--- a/tests/Feature/DepartmentManagementTest.php
+++ b/tests/Feature/DepartmentManagementTest.php
@@ -67,11 +67,10 @@ class DepartmentManagementTest extends TestCase
             'name' => 'Test Department',
         ];
 
-        $response = $this->from(route('company.department.create', $this->company))
-            ->post(
-                route('company.department.store', $this->company),
-                $departmentData
-            );
+        $response = $this->post(
+            route('company.department.store', $this->company),
+            $departmentData
+        );
 
         $response->assertRedirect(route('company.list'));
 
@@ -85,10 +84,9 @@ class DepartmentManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.department.create', $this->company))
-            ->post(route('company.department.store', $this->company), [
-                'name' => '',
-            ]);
+        $response = $this->post(route('company.department.store', $this->company), [
+            'name' => '',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -97,10 +95,9 @@ class DepartmentManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.department.create', $this->company))
-            ->post(route('company.department.store', $this->company), [
-                'name' => 'AB',
-            ]);
+        $response = $this->post(route('company.department.store', $this->company), [
+            'name' => 'AB',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -109,10 +106,9 @@ class DepartmentManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.department.create', $this->company))
-            ->post(route('company.department.store', $this->company), [
-                'name' => str_repeat('A', 21),
-            ]);
+        $response = $this->post(route('company.department.store', $this->company), [
+            'name' => str_repeat('A', 21),
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -145,16 +141,12 @@ class DepartmentManagementTest extends TestCase
             'name' => 'Old Name',
         ]);
 
-        $response = $this->from(route('company.department.update', [
+        $response = $this->post(route('company.department.modify', [
             'company' => $this->company,
             'department' => $department,
-        ]))
-            ->post(route('company.department.modify', [
-                'company' => $this->company,
-                'department' => $department,
-            ]), [
-                'name' => 'New Department Name',
-            ]);
+        ]), [
+            'name' => 'New Department Name',
+        ]);
 
         $response->assertRedirect(route('company.list'));
 
@@ -177,14 +169,10 @@ class DepartmentManagementTest extends TestCase
             'dep_id' => $department->id,
         ]);
 
-        $response = $this->from(route('company.department.index', [
+        $response = $this->post(route('company.department.posts', [
             'company' => $this->company,
             'department' => $department,
-        ]))
-            ->post(route('company.department.posts', [
-                'company' => $this->company,
-                'department' => $department,
-            ]));
+        ]));
 
         $response->assertStatus(200);
         $response->assertJsonCount(3);

--- a/tests/Feature/FieldManagementTest.php
+++ b/tests/Feature/FieldManagementTest.php
@@ -48,11 +48,10 @@ class FieldManagementTest extends TestCase
             'link' => 'https://example.com',
         ];
 
-        $response = $this->from(route('company.field.create', $this->company))
-            ->post(
-                route('company.field.store', $this->company),
-                $fieldData
-            );
+        $response = $this->post(
+            route('company.field.store', $this->company),
+            $fieldData
+        );
 
         $response->assertRedirect(route('company.list', $this->company));
         $response->assertSessionHas('success', 'Successfully created');
@@ -72,11 +71,10 @@ class FieldManagementTest extends TestCase
             'title' => 'Test Field',
         ];
 
-        $response = $this->from(route('company.field.create', $this->company))
-            ->post(
-                route('company.field.store', $this->company),
-                $fieldData
-            );
+        $response = $this->post(
+            route('company.field.store', $this->company),
+            $fieldData
+        );
 
         $response->assertRedirect(route('company.list', $this->company));
         $response->assertSessionHas('success', 'Successfully created');
@@ -91,11 +89,10 @@ class FieldManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.field.create', $this->company))
-            ->post(route('company.field.store', $this->company), [
-                'title' => '',
-                'link' => 'https://example.com',
-            ]);
+        $response = $this->post(route('company.field.store', $this->company), [
+            'title' => '',
+            'link' => 'https://example.com',
+        ]);
 
         $response->assertSessionHasErrors('title');
     }
@@ -104,11 +101,10 @@ class FieldManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.field.create', $this->company))
-            ->post(route('company.field.store', $this->company), [
-                'title' => 'AB',
-                'link' => 'https://example.com',
-            ]);
+        $response = $this->post(route('company.field.store', $this->company), [
+            'title' => 'AB',
+            'link' => 'https://example.com',
+        ]);
 
         $response->assertSessionHasErrors('title');
     }
@@ -117,11 +113,10 @@ class FieldManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.field.create', $this->company))
-            ->post(route('company.field.store', $this->company), [
-                'title' => str_repeat('A', 31),
-                'link' => 'https://example.com',
-            ]);
+        $response = $this->post(route('company.field.store', $this->company), [
+            'title' => str_repeat('A', 31),
+            'link' => 'https://example.com',
+        ]);
 
         $response->assertSessionHasErrors('title');
     }
@@ -157,17 +152,13 @@ class FieldManagementTest extends TestCase
         $field->link = 'https://old-example.com';
         $field->save();
 
-        $response = $this->from(route('company.field.update', [
+        $response = $this->post(route('company.field.modify', [
             'company' => $this->company,
             'field' => $field,
-        ]))
-            ->post(route('company.field.modify', [
-                'company' => $this->company,
-                'field' => $field,
-            ]), [
-                'title' => 'New Title',
-                'link' => 'https://new-example.com',
-            ]);
+        ]), [
+            'title' => 'New Title',
+            'link' => 'https://new-example.com',
+        ]);
 
         $response->assertRedirect(route('company.list', $this->company));
         $response->assertSessionHas('success', 'Successfully updated');

--- a/tests/Feature/PermissionManagementTest.php
+++ b/tests/Feature/PermissionManagementTest.php
@@ -50,11 +50,10 @@ class PermissionManagementTest extends TestCase
             'value' => 'test_permission',
         ];
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(
-                route('company.permission.store', $this->company),
-                $permissionData
-            );
+        $response = $this->post(
+            route('company.permission.store', $this->company),
+            $permissionData
+        );
 
         $response->assertRedirect(route('company.list'));
 
@@ -69,11 +68,10 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => '',
-                'value' => 'test_value',
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => '',
+            'value' => 'test_value',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -82,11 +80,10 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => 'Test Permission',
-                'value' => '',
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => 'Test Permission',
+            'value' => '',
+        ]);
 
         $response->assertSessionHasErrors('value');
     }
@@ -95,11 +92,10 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => 'AB',
-                'value' => 'test_value',
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => 'AB',
+            'value' => 'test_value',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -108,8 +104,7 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
+        $response = $this->post(route('company.permission.store', $this->company), [
             'name' => str_repeat('A', 31),
             'value' => 'test_value',
         ]);
@@ -121,11 +116,10 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => 'Test Permission',
-                'value' => 'ab',
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => 'Test Permission',
+            'value' => 'ab',
+        ]);
 
         $response->assertSessionHasErrors('value');
     }
@@ -134,11 +128,10 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => 'Test Permission',
-                'value' => str_repeat('a', 21),
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => 'Test Permission',
+            'value' => str_repeat('a', 21),
+        ]);
 
         $response->assertSessionHasErrors('value');
     }
@@ -147,11 +140,10 @@ class PermissionManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => 'Test Permission',
-                'value' => 'Invalid-Value',
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => 'Test Permission',
+            'value' => 'Invalid-Value',
+        ]);
 
         $response->assertSessionHasErrors('value');
     }
@@ -165,11 +157,10 @@ class PermissionManagementTest extends TestCase
             'value' => 'existing_value',
         ]);
 
-        $response = $this->from(route('company.permission.create', $this->company))
-            ->post(route('company.permission.store', $this->company), [
-                'name' => 'Test Permission',
-                'value' => 'existing_value',
-            ]);
+        $response = $this->post(route('company.permission.store', $this->company), [
+            'name' => 'Test Permission',
+            'value' => 'existing_value',
+        ]);
 
         $response->assertRedirect(route('company.list'));
         $response->assertSessionHasErrors();
@@ -203,16 +194,12 @@ class PermissionManagementTest extends TestCase
             'name' => 'Old Name',
         ]);
 
-        $response = $this->from(route('company.permission.update', [
+        $response = $this->post(route('company.permission.modify', [
             'company' => $this->company,
             'permission' => $permission,
-        ]))
-            ->post(route('company.permission.modify', [
-                'company' => $this->company,
-                'permission' => $permission,
-            ]), [
-                'name' => 'New Permission Name',
-            ]);
+        ]), [
+            'name' => 'New Permission Name',
+        ]);
 
         $response->assertRedirect(route('company.list'));
 
@@ -279,8 +266,7 @@ class PermissionManagementTest extends TestCase
         $user = User::factory()->create(['role' => 'user']);
         $this->actingAs($user);
 
-        $response = $this->from(route('company.list'))
-            ->get(route('company.permission.create', $this->company));
+        $response = $this->get(route('company.permission.create', $this->company));
 
         $response->assertStatus(403);
     }

--- a/tests/Feature/PostManagementTest.php
+++ b/tests/Feature/PostManagementTest.php
@@ -80,14 +80,10 @@ class PostManagementTest extends TestCase
             'name' => 'Test Post',
         ];
 
-        $response = $this->from(route('company.department.post.create', [
+        $response = $this->post(route('company.department.post.store', [
             'company' => $this->company,
             'department' => $this->department,
-        ]))
-            ->post(route('company.department.post.store', [
-                'company' => $this->company,
-                'department' => $this->department,
-            ]), $postData);
+        ]), $postData);
 
         $response->assertRedirect(route('company.department.index', [
             'company' => $this->company,
@@ -115,14 +111,10 @@ class PostManagementTest extends TestCase
             'permission' => [$permission->id],
         ];
 
-        $response = $this->from(route('company.department.post.create', [
+        $response = $this->post(route('company.department.post.store', [
             'company' => $this->company,
             'department' => $this->department,
-        ]))
-            ->post(route('company.department.post.store', [
-                'company' => $this->company,
-                'department' => $this->department,
-            ]), $postData);
+        ]), $postData);
 
         $response->assertRedirect();
         $response->assertSessionHas('success', 'Successfully created');
@@ -138,16 +130,12 @@ class PostManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.department.post.create', [
+        $response = $this->post(route('company.department.post.store', [
             'company' => $this->company,
             'department' => $this->department,
-        ]))
-            ->post(route('company.department.post.store', [
-                'company' => $this->company,
-                'department' => $this->department,
-            ]), [
-                'name' => '',
-            ]);
+        ]), [
+            'name' => '',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -156,16 +144,12 @@ class PostManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.department.post.create', [
+        $response = $this->post(route('company.department.post.store', [
             'company' => $this->company,
             'department' => $this->department,
-        ]))
-            ->post(route('company.department.post.store', [
-                'company' => $this->company,
-                'department' => $this->department,
-            ]), [
-                'name' => 'AB',
-            ]);
+        ]), [
+            'name' => 'AB',
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -174,16 +158,12 @@ class PostManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.department.post.create', [
+        $response = $this->post(route('company.department.post.store', [
             'company' => $this->company,
             'department' => $this->department,
-        ]))
-            ->post(route('company.department.post.store', [
-                'company' => $this->company,
-                'department' => $this->department,
-            ]), [
-                'name' => str_repeat('A', 31),
-            ]);
+        ]), [
+            'name' => str_repeat('A', 31),
+        ]);
 
         $response->assertSessionHasErrors('name');
     }
@@ -221,18 +201,13 @@ class PostManagementTest extends TestCase
             'name' => 'Old Name',
         ]);
 
-        $response = $this->from(route('company.department.post.update', [
+        $response = $this->post(route('company.department.post.modify', [
             'company' => $this->company,
             'department' => $this->department,
             'post' => $post,
-        ]))
-            ->post(route('company.department.post.modify', [
-                'company' => $this->company,
-                'department' => $this->department,
-                'post' => $post,
-            ]), [
-                'name' => 'New Post Name',
-            ]);
+        ]), [
+            'name' => 'New Post Name',
+        ]);
 
         $response->assertRedirect(route('company.department.index', [
             'company' => $this->company,

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -60,11 +60,10 @@ class UserManagementTest extends TestCase
             'in_bot_role' => 'user',
         ];
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(
-                route('company.user.store', $this->company),
-                $userData
-            );
+        $response = $this->post(
+            route('company.user.store', $this->company),
+            $userData
+        );
 
         $response->assertRedirect(route('company.list'));
 
@@ -85,15 +84,14 @@ class UserManagementTest extends TestCase
 
         User::factory()->create(['login' => 'existinguser']);
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(route('company.user.store', $this->company), [
-                'login' => 'existinguser',
-                'full_name' => 'New User',
-                'department' => $this->department->id,
-                'phone_number' => '+1234567890',
-                'password' => 'password123',
-                'in_bot_role' => 'user',
-            ]);
+        $response = $this->post(route('company.user.store', $this->company), [
+            'login' => 'existinguser',
+            'full_name' => 'New User',
+            'department' => $this->department->id,
+            'phone_number' => '+1234567890',
+            'password' => 'password123',
+            'in_bot_role' => 'user',
+        ]);
 
         $response->assertSessionHasErrors('login');
     }
@@ -102,15 +100,14 @@ class UserManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(route('company.user.store', $this->company), [
-                'login' => 'testuser',
-                'full_name' => '',
-                'department' => $this->department->id,
-                'phone_number' => '+1234567890',
-                'password' => 'password123',
-                'in_bot_role' => 'user',
-            ]);
+        $response = $this->post(route('company.user.store', $this->company), [
+            'login' => 'testuser',
+            'full_name' => '',
+            'department' => $this->department->id,
+            'phone_number' => '+1234567890',
+            'password' => 'password123',
+            'in_bot_role' => 'user',
+        ]);
 
         $response->assertSessionHasErrors('full_name');
     }
@@ -119,15 +116,14 @@ class UserManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(route('company.user.store', $this->company), [
-                'login' => 'testuser',
-                'full_name' => 'Test User',
-                'department' => $this->department->id,
-                'phone_number' => '',
-                'password' => 'password123',
-                'in_bot_role' => 'user',
-            ]);
+        $response = $this->post(route('company.user.store', $this->company), [
+            'login' => 'testuser',
+            'full_name' => 'Test User',
+            'department' => $this->department->id,
+            'phone_number' => '',
+            'password' => 'password123',
+            'in_bot_role' => 'user',
+        ]);
 
         $response->assertSessionHasErrors('phone_number');
     }
@@ -136,15 +132,14 @@ class UserManagementTest extends TestCase
     {
         $this->actingAs($this->admin);
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(route('company.user.store', $this->company), [
-                'login' => 'testuser',
-                'full_name' => 'Test User',
-                'department' => $this->department->id,
-                'phone_number' => '+1234567890',
-                'password' => '12345',
-                'in_bot_role' => 'user',
-            ]);
+        $response = $this->post(route('company.user.store', $this->company), [
+            'login' => 'testuser',
+            'full_name' => 'Test User',
+            'department' => $this->department->id,
+            'phone_number' => '+1234567890',
+            'password' => '12345',
+            'in_bot_role' => 'user',
+        ]);
 
         $response->assertSessionHasErrors('password');
     }
@@ -159,15 +154,14 @@ class UserManagementTest extends TestCase
             'in_bot_role' => 'director',
         ]);
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(route('company.user.store', $this->company), [
-                'login' => 'testuser',
-                'full_name' => 'Test User',
-                'department' => $this->department->id,
-                'phone_number' => '+1234567890',
-                'password' => 'password123',
-                'in_bot_role' => 'director',
-            ]);
+        $response = $this->post(route('company.user.store', $this->company), [
+            'login' => 'testuser',
+            'full_name' => 'Test User',
+            'department' => $this->department->id,
+            'phone_number' => '+1234567890',
+            'password' => 'password123',
+            'in_bot_role' => 'director',
+        ]);
 
         $response->assertRedirect();
         $response->assertSessionHasErrors();
@@ -183,15 +177,14 @@ class UserManagementTest extends TestCase
             'in_bot_role' => 'cashier',
         ]);
 
-        $response = $this->from(route('company.user.create', $this->company))
-            ->post(route('company.user.store', $this->company), [
-                'login' => 'testuser',
-                'full_name' => 'Test User',
-                'department' => $this->department->id,
-                'phone_number' => '+1234567890',
-                'password' => 'password123',
-                'in_bot_role' => 'cashier',
-            ]);
+        $response = $this->post(route('company.user.store', $this->company), [
+            'login' => 'testuser',
+            'full_name' => 'Test User',
+            'department' => $this->department->id,
+            'phone_number' => '+1234567890',
+            'password' => 'password123',
+            'in_bot_role' => 'cashier',
+        ]);
 
         $response->assertRedirect();
         $response->assertSessionHasErrors();
@@ -227,19 +220,15 @@ class UserManagementTest extends TestCase
             'full_name' => 'Old Name',
         ]);
 
-        $response = $this->from(route('company.user.update', [
+        $response = $this->post(route('company.user.modify', [
             'company' => $this->company,
             'user' => $user,
-        ]))
-            ->post(route('company.user.modify', [
-                'company' => $this->company,
-                'user' => $user,
-            ]), [
-                'department' => $this->department->id,
-                'full_name' => 'Updated Name',
-                'phone_number' => '+9876543210',
-                'in_bot_role' => 'user',
-            ]);
+        ]), [
+            'department' => $this->department->id,
+            'full_name' => 'Updated Name',
+            'phone_number' => '+9876543210',
+            'in_bot_role' => 'user',
+        ]);
 
         $response->assertRedirect(route('company.list'));
 
@@ -259,20 +248,16 @@ class UserManagementTest extends TestCase
             'dep_id' => $this->department->id,
         ]);
 
-        $response = $this->from(route('company.user.update', [
+        $response = $this->post(route('company.user.modify', [
             'company' => $this->company,
             'user' => $user,
-        ]))
-            ->post(route('company.user.modify', [
-                'company' => $this->company,
-                'user' => $user,
-            ]), [
-                'department' => $this->department->id,
-                'full_name' => 'Test User',
-                'phone_number' => '+1234567890',
-                'password' => 'newpassword123',
-                'in_bot_role' => 'user',
-            ]);
+        ]), [
+            'department' => $this->department->id,
+            'full_name' => 'Test User',
+            'phone_number' => '+1234567890',
+            'password' => 'newpassword123',
+            'in_bot_role' => 'user',
+        ]);
 
         $response->assertRedirect(route('company.list'));
 
@@ -371,8 +356,7 @@ class UserManagementTest extends TestCase
             'password' => 'adminpassword123',
         ];
 
-        $response = $this->from(route('admin.index'))
-            ->post(route('admin.store'), $adminData);
+        $response = $this->post(route('admin.store'), $adminData);
 
         $response->assertRedirect(route('company.list'));
 
@@ -417,8 +401,7 @@ class UserManagementTest extends TestCase
 
         $this->actingAs($user);
 
-        $response = $this->from(route('home.index'))
-            ->get(route('user.permission'));
+        $response = $this->get(route('user.permission'));
 
         $response->assertStatus(200);
         $response->assertViewIs('user.permission');
@@ -430,8 +413,7 @@ class UserManagementTest extends TestCase
         $user = User::factory()->create(['role' => 'user']);
         $this->actingAs($user);
 
-        $response = $this->from(route('company.list'))
-            ->get(route('company.user.create', $this->company));
+        $response = $this->get(route('company.user.create', $this->company));
 
         $response->assertStatus(403);
     }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reverts prior test changes related to CSRF and rate limiting. Tests now use direct requests and default middleware/redirect behavior.

- **Refactors**
  - Removed from(...) chaining in feature tests; use direct post/get calls.
  - Removed ThrottleRequests bypass in ApiTest.
  - No production code changes.

<!-- End of auto-generated description by cubic. -->

