### PR TITLE
Correct Permission data saving

### DIFF
--- a/app/Http/Controllers/PermissionController.php
+++ b/app/Http/Controllers/PermissionController.php
@@ -21,6 +21,7 @@ class PermissionController extends Controller
         $req->validate([
             'name' => 'required|min:3|max:30',
             'value' => 'required|min:3|max:20|regex:/^[a-z_]+$/',
+            'data' => 'max:8000',
         ]);
 
         if (@Permission::where('com_id', $company->id)->where('value', $req->value)->first()) {
@@ -32,6 +33,7 @@ class PermissionController extends Controller
             $per->com_id = $company->id;
             $per->name = $req->name;
             $per->value = $req->value;
+            $per->data = $req->data;
             $per->save();
 
             return redirect()->route('company.list');
@@ -49,10 +51,12 @@ class PermissionController extends Controller
     {
         $req = request()->validate([
             'name' => 'required|min:3|max:30',
+            'data' => 'max:8000',
         ]);
 
         if (Company::where('id', $company->id)->exists()) {
             $permission->name = $req['name'];
+            $permission->data = $req['data'];
             $permission->save();
 
             return redirect()->route('company.list');

--- a/resources/views/company/permission/update.blade.php
+++ b/resources/views/company/permission/update.blade.php
@@ -1,29 +1,32 @@
 @extends('layouts.main')
 
-@section('title', 'Изменитть Право '.$permission -> name)
+@section('title', 'Изменитть Право ' . $permission->name)
 
 @section('content')
 
-	<div class="row justify-content-center">
-		<div class="col-lg-6">
-			<h2 class="text-center mt-4">Изменить право доступа <b>{{$permission -> name}}</b> в <b>{{$company -> name}}</b></h2>
-			<form action="{{route('company.permission.modify', compact('company', 'permission'))}}" method="post" class="bg-body-tertiary rounded p-3">
-				@csrf
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <h2 class="text-center mt-4">Изменить право доступа <b>{{ $permission->name }}</b> в
+                <b>{{ $company->name }}</b></h2>
+            <form action="{{ route('company.permission.modify', compact('company', 'permission')) }}" method="post"
+                class="bg-body-tertiary rounded p-3">
+                @csrf
 
-				<div class="form-group mb-2">
-					<label for="name">Название:</label>
-					<input type="text" class="form-control" id="name" name="name" value="{{$permission -> name}}" required>
-				</div>
+                <div class="form-group mb-2">
+                    <label for="name">Название:</label>
+                    <input type="text" class="form-control" id="name" name="name" value="{{ $permission->name }}"
+                        required>
+                </div>
 
-				<div class="form-group mb-2">
-					<label for="data">Значение:</label>
-					<textarea class="form-control" name="data" id="data" cols="30" rows="10">{{$permission -> data}}</textarea>
-				</div>
-				<div class="d-flex justify-content-center">
-					<button type="submit" class="btn btn-primary">Обновить</button>
-				</div>
-			</form>
-		</div>
-	</div>
+                <div class="form-group mb-2">
+                    <label for="data">Значение:</label>
+                    <textarea class="form-control" name="data" id="data" cols="30" rows="10">{{ $permission->data }}</textarea>
+                </div>
+                <div class="d-flex justify-content-center">
+                    <button type="submit" class="btn btn-primary">Обновить</button>
+                </div>
+            </form>
+        </div>
+    </div>
 
 @endsection

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -147,7 +147,7 @@
 
 </head>
 
-<body data-bs-theme="{{ session('theme') ?? 'light' }}">
+<body data-bs-theme="{{ session('theme') ?? 'dark' }}">
 
     <header>
         <nav class="navbar navbar-expand-lg bg-body-secondary px-2h">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes saving of the permission data field on create and edit to prevent lost values. Also sets the default UI theme to dark when no session theme is set.

- **Bug Fixes**
  - Validate and persist permission data (max 8000 chars) in store/modify actions.

- **New Features**
  - Default UI theme is now dark if no theme is saved.

<!-- End of auto-generated description by cubic. -->

