### PR TITLE
fix(user-permissions): remove unused class from report cashier form

### DIFF
--- a/resources/views/user/permissions/report_cashier.blade.php
+++ b/resources/views/user/permissions/report_cashier.blade.php
@@ -8,7 +8,7 @@
                     class="bi bi-nintendo-switch"></i></button>
         </span>
         <form id="perm_panel_report_cashier" action="{{ route('mod.report_cashier', $data->company->id) }}" method="post"
-            class="perm-panel-list perm-panel bg-body-tertiary rounded p-3" enctype="multipart/form-data">
+            class=" perm-panel bg-body-tertiary rounded p-3" enctype="multipart/form-data">
             @csrf
 
             <div class="form-group mb-2">


### PR DESCRIPTION
- Deleted the redundant "perm-panel-list" class from the form element in report_cashier view
- Cleaned up the HTML markup for better maintainability
- Ensured no functional impact by this class removal in the permission panel form styling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused perm-panel-list class from the report_cashier permission form to clean up the HTML and avoid dead styles. No functional or visual changes.

<!-- End of auto-generated description by cubic. -->

